### PR TITLE
feat: :sparkles: Add ITF Card Type

### DIFF
--- a/lib/pages/createcardnew.dart
+++ b/lib/pages/createcardnew.dart
@@ -300,6 +300,18 @@ class _CreateCardState extends State<CreateCard> {
       } else {
         return true;
       }
+    } else if (cardTypeText == 'CardType.itf') {
+      return int.tryParse(eanCode) != null;
+    } else if (cardTypeText == 'CardType.itf14') {
+      return
+        int.tryParse(eanCode) != null
+        && eanCode.length <= 13
+        && eanCode.length >= 14;
+    } else if (cardTypeText == 'CardType.itf16') {
+      return
+        int.tryParse(eanCode) != null
+        && eanCode.length <= 15
+        && eanCode.length >= 16;
     } else if (cardTypeText == 'CardType.upca') {
       if (eanCode.length != 12 || int.tryParse(eanCode) == null) {
         return false;

--- a/lib/pages/createcardnew.dart
+++ b/lib/pages/createcardnew.dart
@@ -302,16 +302,6 @@ class _CreateCardState extends State<CreateCard> {
       }
     } else if (cardTypeText == 'CardType.itf') {
       return int.tryParse(eanCode) != null;
-    } else if (cardTypeText == 'CardType.itf14') {
-      return
-        int.tryParse(eanCode) != null
-        && eanCode.length <= 13
-        && eanCode.length >= 14;
-    } else if (cardTypeText == 'CardType.itf16') {
-      return
-        int.tryParse(eanCode) != null
-        && eanCode.length <= 15
-        && eanCode.length >= 16;
     } else if (cardTypeText == 'CardType.upca') {
       if (eanCode.length != 12 || int.tryParse(eanCode) == null) {
         return false;

--- a/lib/pages/createcardnew.dart
+++ b/lib/pages/createcardnew.dart
@@ -14,6 +14,9 @@ enum CardType {
   ean8('EAN-8', 'ean8'),
   ean5('EAN-5', 'ean5'),
   ean2('EAN-2', 'ean2'),
+  itf('ITF', 'itf'),
+  itf14('ITF-14', 'itf14'),
+  itf16('ITF-16', 'itf16'),
   upca('UPC-A', 'upca'),
   upce('UPC-E', 'upce'),
   codabar('Codabar', 'codabar'),
@@ -72,6 +75,12 @@ class _CreateCardState extends State<CreateCard> {
         return 'Type: EAN 5';
       case 'CardType.ean2':
         return 'Type: EAN 2';
+      case 'CardType.itf':
+        return 'Type: ITF';
+      case 'CardType.itf14':
+        return 'Type: ITF-14';
+      case 'CardType.itf16':
+        return 'Type: ITF-16';
       case 'CardType.upca':
         return 'Type: UPC-A';
       case 'CardType.upce':

--- a/lib/pages/editcard.dart
+++ b/lib/pages/editcard.dart
@@ -304,6 +304,18 @@ class _EditCardState extends State<EditCard> {
       } else {
         return true;
       }
+    } else if (cardTypeText == 'CardType.itf') {
+      return int.tryParse(eanCode) != null;
+    } else if (cardTypeText == 'CardType.itf14') {
+      return
+        int.tryParse(eanCode) != null
+        && eanCode.length <= 13
+        && eanCode.length >= 14;
+    } else if (cardTypeText == 'CardType.itf16') {
+      return
+        int.tryParse(eanCode) != null
+        && eanCode.length <= 15
+        && eanCode.length >= 16;
     } else if (cardTypeText == 'CardType.upca') {
       if (eanCode.length != 12 || int.tryParse(eanCode) == null) {
         return false;

--- a/lib/pages/editcard.dart
+++ b/lib/pages/editcard.dart
@@ -306,16 +306,6 @@ class _EditCardState extends State<EditCard> {
       }
     } else if (cardTypeText == 'CardType.itf') {
       return int.tryParse(eanCode) != null;
-    } else if (cardTypeText == 'CardType.itf14') {
-      return
-        int.tryParse(eanCode) != null
-        && eanCode.length <= 13
-        && eanCode.length >= 14;
-    } else if (cardTypeText == 'CardType.itf16') {
-      return
-        int.tryParse(eanCode) != null
-        && eanCode.length <= 15
-        && eanCode.length >= 16;
     } else if (cardTypeText == 'CardType.upca') {
       if (eanCode.length != 12 || int.tryParse(eanCode) == null) {
         return false;

--- a/lib/pages/editcard.dart
+++ b/lib/pages/editcard.dart
@@ -14,6 +14,9 @@ enum CardType {
   ean8('EAN-8', 'ean8'),
   ean5('EAN-5', 'ean5'),
   ean2('EAN-2', 'ean2'),
+  itf('ITF', 'itf'),
+  itf14('ITF-14', 'itf14'),
+  itf16('ITF-16', 'itf16'),
   upca('UPC-A', 'upca'),
   upce('UPC-E', 'upce'),
   codabar('Codabar', 'codabar'),
@@ -74,6 +77,12 @@ class _EditCardState extends State<EditCard> {
         return 'Type: EAN 5';
       case 'CardType.ean2':
         return 'Type: EAN 2';
+      case 'CardType.itf':
+        return 'Type: ITF';
+      case 'CardType.itf14':
+        return 'Type: ITF-14';
+      case 'CardType.itf16':
+        return 'Type: ITF-16';
       case 'CardType.upca':
         return 'Type: UPC-A';
       case 'CardType.upce':

--- a/lib/pages/generate_barcode_page.dart
+++ b/lib/pages/generate_barcode_page.dart
@@ -81,6 +81,12 @@ class _GenerateBarcodeState extends State<GenerateBarcode> {
         return Barcode.ean5();
       case 'CardType.ean2':
         return Barcode.ean2();
+      case 'CardType.itf':
+        return Barcode.itf();
+      case 'CardType.itf14':
+        return Barcode.itf14();
+      case 'CardType.itf16':
+        return Barcode.itf16();
       case 'CardType.upca':
         return Barcode.upcA();
       case 'CardType.upce':


### PR DESCRIPTION
I have a fidelity card which use the Interleaved 2 of 5 (ITF) format but unfortunately it was not implemented in the app.
I checked that the flutter lib [barcode](https://pub.dev/packages/barcode) already implements those types so I added `ITF`, `ITF-14` &` ITF-16` Card types in the possible types.

Feel free to give any feedback if needed.

PS: I didn't build the app 'cause i got trouble setting up Flutter correctly on this computer, so I hope it will be all good.