### PR TITLE
fix: contain wide card images upon selection

### DIFF
--- a/lib/util/camera_controller.dart
+++ b/lib/util/camera_controller.dart
@@ -271,7 +271,7 @@ class _CameraControllerScreenState extends State<CameraControllerScreen>
                               child: SizedBox.expand(
                                 child: Image.file(
                                   File(_capturedImageFile!.path),
-                                  fit: BoxFit.cover,
+                                  fit: BoxFit.contain,
                                 ),
                               ),
                             ),


### PR DESCRIPTION
This change addresses issue with unreleased redesign of card image selection + cropping mentioned in https://github.com/GeorgeYT9769/cardabase-app/issues/72#issuecomment-4320176928.

Before:

<img height="200" alt="Screenshot_20260425_202336" src="https://github.com/user-attachments/assets/e467cfce-547e-4ae4-b0e3-202501206402" />

After:

<img height="200" alt="Screenshot_20260425_202501" src="https://github.com/user-attachments/assets/f064fe21-29ca-4f80-9e3b-b827e521bbb9" />
