### PR TITLE
fix: do not ask for unused microphone permission

### DIFF
--- a/lib/util/camera_controller.dart
+++ b/lib/util/camera_controller.dart
@@ -58,6 +58,7 @@ class _CameraControllerScreenState extends State<CameraControllerScreen>
     _cameraController = CameraController(
       _cameras![0],
       ResolutionPreset.high,
+      enableAudio: false,
       imageFormatGroup: ImageFormatGroup.jpeg,
     );
     _initializeControllerFuture = _cameraController!.initialize();


### PR DESCRIPTION
I started digging into the microphone issue to fix https://github.com/GeorgeYT9769/cardabase-app/issues/49. The first and obvious thing I looked at was `availableCameras()` call at

https://github.com/GeorgeYT9769/cardabase-app/blob/4a332ca1c0364f36a0b95816b65213d83ca3ba7d/lib/util/camera_controller.dart?plain=1#L54

However, it didn't give me anything useful. I did found some `enableAudio` stuff in the camera package. I then got desperate and decided to try deepwiki.com. And after a bit of waiting, I got https://deepwiki.com/search/when-defining-futurelistcamera_d16903c6-7915-4354-95dd-9464c75502b6?mode=deep, which revealed that

> **`enableAudio` is true somewhere upstream.** The `createCamera()` default is `enableAudio: false`, but if the downstream library or app's `CameraController` is calling `createCameraWithSettings()` with `enableAudio: true` (e.g., because it defaults to enabling audio for video recording capability), the microphone permission will be requested even if the app never actually records audio.

Which has the keyword `CameraController`, which is exactly what's being called right below:

https://github.com/GeorgeYT9769/cardabase-app/blob/4a332ca1c0364f36a0b95816b65213d83ca3ba7d/lib/util/camera_controller.dart?plain=1#L53-L66

Dart has a very quirky and unique syntax with 1000 ways of how arguments can be passed (I guess similar to Python), but doc hover revealed that `CameraController` has the `enableAudio` which is `true` by default! Now it's off and no mic permission is requested. [Great success!](https://i.imgflip.com/4/1t6r0w.jpg)
